### PR TITLE
Recording SOATest StdViol as JUnit testcase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+work
 .classpath
 .settings
 .project
 /target/
+*.iml
+.idea


### PR DESCRIPTION
This allows users who have test configurations that report static
analysis violations to visualize violaitons in Jenkins. The violations
are categorized by (SOATest) project and rule.

This is not tested with a wide variety of analysis violations. It
assumes that all violations have the attributes project, rule, uri,
msg and ln. There is no error handling.

I have also added minimal support for Intellij to the .gitignore.