### PR TITLE
Fix bug of not downloading rules from DTP if running on a remote agent only.

### DIFF
--- a/src/main/java/com/parasoft/findings/jenkins/internal/rules/RuleDocumentationStorage.java
+++ b/src/main/java/com/parasoft/findings/jenkins/internal/rules/RuleDocumentationStorage.java
@@ -130,23 +130,7 @@ public class RuleDocumentationStorage
     private void storeRuleDoc(FilePath rootDir, String ruleDocDir, String analyzer, String ruleId, String contents)
     {
         try {
-            rootDir.act(new FileCallable<Boolean>()
-            {
-                private static final long serialVersionUID = 1L;
-
-                @Override
-                public Boolean invoke(File file, VirtualChannel channel)
-                    throws IOException, InterruptedException
-                {
-                    internalStoreRuleDoc(file, RuleDocumentationReader.getRuleDocRelativePath(ruleDocDir, analyzer, ruleId), contents);
-                    return Boolean.TRUE;
-                }
-
-                @Override
-                public void checkRoles(RoleChecker arg0)
-                    throws SecurityException
-                {}
-            });
+            rootDir.act(new InternalStoreRuleDocFileCallable(ruleDocDir, analyzer, ruleId, contents));
         } catch (IOException e) {
             Logger.getLogger().errorTrace(e);
         } catch (InterruptedException e) {
@@ -154,7 +138,37 @@ public class RuleDocumentationStorage
         }
     }
 
-    private void internalStoreRuleDoc(File rootDir, String ruleDocFile, String contents)
+    private static final class InternalStoreRuleDocFileCallable implements FileCallable<Boolean> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String ruleDocDir;
+        private final String analyzer;
+        private final String ruleId;
+        private final String contents;
+
+        InternalStoreRuleDocFileCallable(String ruleDocDir, String analyzer, String ruleId, String contents) {
+            this.ruleDocDir = ruleDocDir;
+            this.analyzer = analyzer;
+            this.ruleId = ruleId;
+            this.contents = contents;
+        }
+
+        @Override
+        public Boolean invoke(File file, VirtualChannel channel)
+                throws IOException, InterruptedException
+        {
+            internalStoreRuleDoc(file, RuleDocumentationReader.getRuleDocRelativePath(ruleDocDir, analyzer, ruleId), contents);
+            return Boolean.TRUE;
+        }
+
+        @Override
+        public void checkRoles(RoleChecker arg0)
+                throws SecurityException
+        {}
+    }
+
+    private static void internalStoreRuleDoc(File rootDir, String ruleDocFile, String contents)
     {
         Writer writer = null;
         try {

--- a/src/main/java/com/parasoft/findings/jenkins/tool/ParasoftTool.java
+++ b/src/main/java/com/parasoft/findings/jenkins/tool/ParasoftTool.java
@@ -38,6 +38,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import com.parasoft.findings.jenkins.html.IHtmlTags;
 import com.parasoft.findings.jenkins.internal.rules.JenkinsRulesUtil;
 import com.parasoft.findings.jenkins.internal.rules.RuleDocumentationStorage;
+import com.parasoft.findings.jenkins.internal.services.JenkinsServicesProvider;
 import com.parasoft.findings.jenkins.internal.variables.JenkinsVariablesResolver;
 
 import edu.hm.hafner.analysis.Issue;
@@ -96,6 +97,7 @@ public class ParasoftTool
 
         Iterator<Issue> issues = report.iterator();
 
+        JenkinsServicesProvider.init();
         RuleDocumentationStorage storage = new RuleDocumentationStorage(run.getRootDir(), _settings);
         while (issues.hasNext()) {
 

--- a/src/main/java/com/parasoft/findings/jenkins/util/FilePathUtil.java
+++ b/src/main/java/com/parasoft/findings/jenkins/util/FilePathUtil.java
@@ -48,24 +48,7 @@ public final class FilePathUtil
     {
         boolean result = false;
         try {
-            result = file.act(new FileCallable<Boolean>()
-            {
-                private static final long serialVersionUID = 1L;
-
-                public Boolean invoke(File f, VirtualChannel channel)
-                    throws IOException, InterruptedException
-                {
-                    return f.isAbsolute();
-                }
-
-                @Override
-                public void checkRoles(RoleChecker arg0)
-                    throws SecurityException
-                {
-                    // TODO Auto-generated method stub
-                    
-                }
-            });
+            result = file.act(new IsAbsoluteFileCallable());
         } catch (IOException e) {
             Logger.getLogger().errorTrace(e);
         } catch (InterruptedException e) {
@@ -82,32 +65,7 @@ public final class FilePathUtil
     {
         Properties props = null;
         try {
-            props = file.act(new FileCallable<Properties>()
-            {
-                private static final long serialVersionUID = -286350596197180650L;
-
-                public Properties invoke(File f, VirtualChannel channel)
-                    throws IOException, InterruptedException
-                {
-                    Logger.getLogger().info("File path is " + f.getAbsolutePath());   //$NON-NLS-1$
-                    InputStream input = new FileInputStream(f);
-                    try {
-                        Properties properties = new Properties();
-                        properties.load(input);
-                        return properties;
-                    } finally {
-                        IOUtils.closeQuietly(input);
-                    }
-                }
-
-                @Override
-                public void checkRoles(RoleChecker arg0)
-                    throws SecurityException
-                {
-                    // TODO Auto-generated method stub
-                    
-                }
-            });
+            props = file.act(new LoadPropertiesFileCallable());
         } catch (IOException e) {
             Logger.getLogger().error("Localsettings file not found", e); //$NON-NLS-1$
         } catch (InterruptedException e) {
@@ -118,6 +76,52 @@ public final class FilePathUtil
             Logger.getLogger().info("No properties loaded"); //$NON-NLS-1$
         }
         return props;
+    }
+
+    private static final class IsAbsoluteFileCallable implements FileCallable<Boolean> {
+
+        private static final long serialVersionUID = 1L;
+
+        public Boolean invoke(File f, VirtualChannel channel)
+                throws IOException, InterruptedException
+        {
+            return f.isAbsolute();
+        }
+
+        @Override
+        public void checkRoles(RoleChecker arg0)
+                throws SecurityException
+        {
+            // TODO Auto-generated method stub
+
+        }
+    }
+
+    private static final class LoadPropertiesFileCallable implements FileCallable<Properties> {
+
+        private static final long serialVersionUID = -286350596197180650L;
+
+        public Properties invoke(File f, VirtualChannel channel)
+                throws IOException, InterruptedException
+        {
+            Logger.getLogger().info("File path is " + f.getAbsolutePath());   //$NON-NLS-1$
+            InputStream input = new FileInputStream(f);
+            try {
+                Properties properties = new Properties();
+                properties.load(input);
+                return properties;
+            } finally {
+                IOUtils.closeQuietly(input);
+            }
+        }
+
+        @Override
+        public void checkRoles(RoleChecker arg0)
+                throws SecurityException
+        {
+            // TODO Auto-generated method stub
+
+        }
     }
 }
     


### PR DESCRIPTION
Fix bug of not downloading rules from DTP if running on a remote agent only.
Also remove warning in Jenkins log related to serialization of anonymous classes, see: [How to serialize anonymous classes](https://www.jenkins.io/doc/developer/extensibility/serialization-of-anonymous-classes/)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
