### PR TITLE
Update xUnit transform unit tests to use Saxon-HE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,11 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
+        <!--  shared by xunit and warnings-ng - synchronize with xunit(use version as in dtkit-metrics-util) -->
+        <exclusion>
+          <groupId>net.sf.saxon</groupId>
+          <artifactId>Saxon-HE</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- these artifacts versions are defined in com.parasoft.xtest:build pom -->
@@ -512,12 +517,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.10.19</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>saxon</groupId>
-      <artifactId>saxon</artifactId>
-      <version>6.5.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
The *Saxon-HE* library is used in some SOAtest marketplace extensions([Data Repository Migration](https://docs.parasoft.com/display/SOA20231/Data+Repository+Migration#DataRepositoryMigration-Third-PartyContent) and [WebSocket Transport Extension](https://docs.parasoft.com/display/SOA20231/WebSocket+Transport+Extension+1.0#WebSocketTransportExtension1.0-Third-partyContent)) with license *Mozilla Public License 2.0*.

We can see Findings plugin does not directly use the Saxon library in the implementation source code, it is only used in the unit tests. After some research and debugging, I find that the [`ConversionService#convert`](https://github.com/jenkinsci/libdtkit/blob/3083711c0f9146132da41c056ffda6933cd91693/dtkit-metrics-util/src/main/java/org/jenkinsci/lib/dtkit/util/converter/ConversionService.java#LL239C22-L239C22) method in *DTKit 2 API* plugin(a dependency of *xUnit* plugin) is the actual place where the XSL transformation happens, and it already uses the *Saxon-HE* library. The `Xslt30Transformer` from *Saxon-HE* library is used for the transformation, which supports XSLT 2.0 and XSLT 3.0. So we can already use XSLT 2.0 and XSLT 3.0 features in the xsl files in Findings pluin.

Based on the above research result, there's no need to change the runtime dependency and source code of Findings plugin, only the unit tests are updated to use the same version of the *Saxon-HE* library as *DTKit 2 API* plugin in this task.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
