### PR TITLE
Add Code Coverage API dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
     </resources>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <additionalClasspathElements>
@@ -101,7 +100,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
@@ -138,7 +136,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
           <checkModificationExcludes>
@@ -171,30 +168,47 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Work around "Require upper bound dependencies error for io.jenkins.plugins:javax-activation-api:1.2.0-3" for warnings-ng. -->
       <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>javax-activation-api</artifactId>
-        <version>1.2.0-5</version>
+        <groupId>org.jvnet.hudson.plugins</groupId>
+        <artifactId>analysis-pom</artifactId>
+        <version>6.8.0</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
-      <!-- Work around "Require upper bound dependencies error for net.minidev:json-smart:2.4.8" for warnings-ng. -->
+      <!-- Work around "Require upper bound dependencies error" for warnings-ng. -->
       <dependency>
         <groupId>net.minidev</groupId>
         <artifactId>json-smart</artifactId>
         <version>2.4.10</version>
       </dependency>
-      <!-- Work around "Require upper bound dependencies error for org.jsoup:jsoup:1.15.3" for warnings-ng. -->
+      <!-- shared by warnings-ng and code-coverage-api - synchronize with code-coverage-api. -->
       <dependency>
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
-        <version>1.15.4</version>
+        <version>1.16.1</version>
       </dependency>
-      <!-- shared by xunit and warnings-ng - synchronize with warnings-ng
-      Work around "Require upper bound dependencies error for io.jenkins.plugins:jaxb:2.3.6-1" for warnings-ng. -->
+      <!-- shared by warnings-ng and code-coverage-api - synchronize with code-coverage-api. -->
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
-        <artifactId>jaxb</artifactId>
-        <version>2.3.8-1</version>
+        <artifactId>prism-api</artifactId>
+        <version>1.29.0-6</version>
+      </dependency>
+      <!-- shared by warnings-ng, code-coverage-api and xunit - synchronize with code-coverage-api. -->
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>echarts-api</artifactId>
+        <version>5.4.0-4</version>
+      </dependency>
+      <!-- Fix some transitive vulnerable dependency warnings for warnings-ng -->
+      <dependency>
+        <groupId>com.beust</groupId>
+        <artifactId>jcommander</artifactId>
+        <version>1.82</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.bcel</groupId>
+        <artifactId>bcel</artifactId>
+        <version>6.7.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -293,6 +307,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>xunit</artifactId>
       <version>3.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>code-coverage-api</artifactId>
+      <version>4.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>


### PR DESCRIPTION
* Fix dependency conflicts between warnings-ng and code-coverage-api by importing their common parent pom.
* Remove unnecessary groupId for Maven built-in plugins to fix the plugin not found error.
* Fix some transitive vulnerable dependency warnings introduced by warning-ng dependency.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
