### PR TITLE
Create Record Parasoft coverage results post-build action.

### DIFF
--- a/src/main/java/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder.java
+++ b/src/main/java/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 Parasoft Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.parasoft.findings.jenkins.coverage;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import hudson.tasks.Recorder;
+import io.jenkins.plugins.coverage.metrics.steps.CoverageRecorder;
+import io.jenkins.plugins.coverage.metrics.steps.CoverageTool;
+import org.apache.commons.lang3.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ParasoftCoverageRecorder extends Recorder {
+
+    private String pattern = StringUtils.EMPTY;
+    private static final String PARASOFT_COVERAGE_ID = "parasoft-coverage";
+    private static final String PARASOFT_COVERAGE_NAME = "Parasoft Coverage";
+
+    @DataBoundConstructor
+    public ParasoftCoverageRecorder() {
+        super();
+        // empty constructor required for Stapler
+    }
+
+    @DataBoundSetter
+    public void setPattern(final String pattern) {
+        this.pattern = pattern;
+    }
+
+    @CheckForNull
+    public String getPattern() {
+        return pattern;
+    }
+
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {
+        CoverageRecorder recorder = setUpCoverageRecorder(pattern);
+        return recorder.perform(build, launcher, listener);
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+        return (Descriptor) super.getDescriptor();
+    }
+
+    private static CoverageRecorder setUpCoverageRecorder(final String pattern) {
+        CoverageRecorder recorder = new CoverageRecorder();
+        CoverageTool tool = new CoverageTool();
+        tool.setParser(CoverageTool.Parser.COBERTURA);
+        tool.setPattern(pattern);
+        recorder.setTools(List.of(tool));
+        recorder.setId(PARASOFT_COVERAGE_ID);
+        recorder.setName(PARASOFT_COVERAGE_NAME);
+        return recorder;
+    }
+
+    @Extension
+    public static class Descriptor extends BuildStepDescriptor<Publisher> {
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.Recorder_Name();
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder.java
+++ b/src/main/java/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder.java
@@ -38,9 +38,11 @@ import java.util.List;
 
 public class ParasoftCoverageRecorder extends Recorder {
 
-    private String pattern = StringUtils.EMPTY;
     private static final String PARASOFT_COVERAGE_ID = "parasoft-coverage";
     private static final String PARASOFT_COVERAGE_NAME = "Parasoft Coverage";
+    private static final String DEFAULT_PATTERN = "**/coverage.xml";
+
+    private String pattern = StringUtils.EMPTY;
 
     @DataBoundConstructor
     public ParasoftCoverageRecorder() {
@@ -50,7 +52,7 @@ public class ParasoftCoverageRecorder extends Recorder {
 
     @DataBoundSetter
     public void setPattern(final String pattern) {
-        this.pattern = pattern;
+        this.pattern = StringUtils.defaultIfBlank(pattern, DEFAULT_PATTERN);
     }
 
     @CheckForNull
@@ -71,8 +73,8 @@ public class ParasoftCoverageRecorder extends Recorder {
     }
 
     @Override
-    public Descriptor getDescriptor() {
-        return (Descriptor) super.getDescriptor();
+    public ParasoftCoverageDescriptor getDescriptor() {
+        return (ParasoftCoverageDescriptor) super.getDescriptor();
     }
 
     private static CoverageRecorder setUpCoverageRecorder(final String pattern) {
@@ -87,7 +89,7 @@ public class ParasoftCoverageRecorder extends Recorder {
     }
 
     @Extension
-    public static class Descriptor extends BuildStepDescriptor<Publisher> {
+    public static class ParasoftCoverageDescriptor extends BuildStepDescriptor<Publisher> {
 
         @NonNull
         @Override
@@ -98,6 +100,11 @@ public class ParasoftCoverageRecorder extends Recorder {
         @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;
+        }
+
+        // Used in jelly file.
+        public String defaultPattern() {
+            return DEFAULT_PATTERN;
         }
     }
 }

--- a/src/main/resources/com/parasoft/findings/jenkins/coverage/Messages.properties
+++ b/src/main/resources/com/parasoft/findings/jenkins/coverage/Messages.properties
@@ -1,0 +1,1 @@
+Recorder.Name=Record Parasoft code coverage results

--- a/src/main/resources/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder/config.jelly
+++ b/src/main/resources/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder/config.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:st="jelly:stapler" xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <st:documentation>
+        Provides the configuration for the Parasoft coverage recorder and step.
+    </st:documentation>
+
+    <f:entry title="${%title.pattern}" field="pattern"
+             description="${%description.pattern('https://ant.apache.org/manual/Types/fileset.html')}">
+        <f:textbox/>
+    </f:entry>
+
+</j:jelly>

--- a/src/main/resources/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder/config.jelly
+++ b/src/main/resources/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder/config.jelly
@@ -7,7 +7,7 @@
 
     <f:entry title="${%title.pattern}" field="pattern"
              description="${%description.pattern('https://ant.apache.org/manual/Types/fileset.html')}">
-        <f:textbox/>
+        <f:textbox default="${descriptor.defaultPattern()}" placeholder="${descriptor.defaultPattern()}"/>
     </f:entry>
 
 </j:jelly>

--- a/src/main/resources/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder/config.properties
+++ b/src/main/resources/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder/config.properties
@@ -1,0 +1,3 @@
+title.pattern=Report File Pattern
+description.pattern=<a rel="noopener noreferrer" href="{0}">Fileset ''includes''</a> syntax \
+    specifying the Parasoft coverage files to read, such as ''**/coverage.xml''.

--- a/src/main/resources/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder/help-pattern.html
+++ b/src/main/resources/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder/help-pattern.html
@@ -1,0 +1,6 @@
+<div>
+    A pattern is defined by an <a href="https://ant.apache.org/manual/Types/fileset.html">Ant Fileset ''includes''</a>
+    setting that specifies the Parasoft coverage report files to read. Multiple patterns can be separated by space or comma.
+    Note that such a pattern is resolved in Jenkins' workspace, so the paths must be relative only.
+    If no pattern is specified then the default pattern "**/coverage.xml" will be used.
+</div>


### PR DESCRIPTION
### Localization Notes:

The following files under `src/main/resources/com/parasoft/findings/jenkins/coverage` need to be localized.

* `ParasoftCoverageRecorder/config.properties` to `ParasoftCoverageRecorder/config_zh_CN.properties`

* `ParasoftCoverageRecorder/help-pattern.html` to `ParasoftCoverageRecorder/help-pattern_zh_CN.html`

* `Messages.properties` to `Messages_zh_CN.properties`

### Implementation Notes:

1. These English texts are copied from files in [code-coverage-api-plugin/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageTool](https://github.com/jenkinsci/code-coverage-api-plugin/tree/v4.6.0/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageTool) with few modifications.
2. The **Parasoft Coverage** result name on the side panel can not be shown dynamically according to the web browser prefered language, currently it can only be set to a fixed value when the coverage result is published.
3. The localization uses the `Messages` classes generated by [localizer](https://www.jenkins.io/doc/developer/internationalization/i18n-source-code/). To eliminate the red errors on using `Messages` class in IntelliJ IDEA, right click on the `Parasoft Findings` project and select **Generate Sources and Update Folders** in the Maven view, if the problem still exists, select **Reload Project**.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
