### PR TITLE
Get reference build and coverage data according to the configuration.

### DIFF
--- a/src/main/java/com/parasoft/findings/jenkins/coverage/api/metrics/steps/CoverageBuildAction.java
+++ b/src/main/java/com/parasoft/findings/jenkins/coverage/api/metrics/steps/CoverageBuildAction.java
@@ -59,7 +59,7 @@ public final class CoverageBuildAction extends BuildAction<Node> implements Stap
     private static final long serialVersionUID = -6023811049340671399L;
 
     private static final ElementFormatter FORMATTER = new ElementFormatter();
-    private static final String NO_REFERENCE_BUILD = "-";
+    static final String NO_REFERENCE_BUILD = "-";
 
     private final String id;
     private final String name;

--- a/src/main/java/com/parasoft/findings/jenkins/coverage/api/metrics/steps/CoverageQualityGate.java
+++ b/src/main/java/com/parasoft/findings/jenkins/coverage/api/metrics/steps/CoverageQualityGate.java
@@ -19,6 +19,7 @@ import com.parasoft.findings.jenkins.coverage.api.metrics.model.ElementFormatter
 import io.jenkins.plugins.util.JenkinsFacade;
 import io.jenkins.plugins.util.QualityGate;
 
+import static com.parasoft.findings.jenkins.coverage.api.metrics.steps.CoverageBuildAction.NO_REFERENCE_BUILD;
 import static hudson.model.PermalinkProjectAction.Permalink.LAST_SUCCESSFUL_BUILD;
 
 /**
@@ -31,7 +32,7 @@ import static hudson.model.PermalinkProjectAction.Permalink.LAST_SUCCESSFUL_BUIL
 public class CoverageQualityGate extends QualityGate {
     private static final long serialVersionUID = -397278599489426668L;
 
-    private static final PermalinkProjectAction.Permalink DEFAULT_REFERENCE_BUILD = LAST_SUCCESSFUL_BUILD;
+    static final PermalinkProjectAction.Permalink DEFAULT_REFERENCE_BUILD = LAST_SUCCESSFUL_BUILD;
 
     private static final ElementFormatter FORMATTER = new ElementFormatter();
 
@@ -66,7 +67,11 @@ public class CoverageQualityGate extends QualityGate {
 
     @DataBoundSetter
     public void setReferenceBuild(String referenceBuild) {
-        this.referenceBuild = referenceBuild;
+        if (Baseline.PROJECT.equals(getBaseline())) {
+            this.referenceBuild = NO_REFERENCE_BUILD;
+        } else {
+            this.referenceBuild = referenceBuild;
+        }
     }
 
     public String getReferenceBuild() {


### PR DESCRIPTION
The following is a test job log for different cases of reference build configuration considered in this implementation.

```
[Coverage] Using default reference build 'lastSuccessfulBuild' for quality gate 'Modified code lines - Line Coverage - UNSTABLE: 0.000000' since user defined reference build is not set
[Coverage] Obtaining action of reference build '1'
[Coverage] -> Using reference build 'DemoProject #1'
[Coverage] -> Found no reference result in reference build 'DemoProject #1'
[Coverage] Obtaining action of reference build '34'
[Coverage] -> Using reference build 'DemoProject #34'
[Coverage] -> Found reference result in build 'DemoProject #34'
[Coverage] Obtaining action of reference build '${BUILD_NUMBER}'
[Coverage] -> Expanding reference build '${BUILD_NUMBER}' to '43'
[Coverage] -> Can not use current build '43' as reference build
[Coverage] -> No reference build defined for '${BUILD_NUMBER}'
[Coverage] Obtaining action of reference build 'lastSuccessfulBuild'
[Coverage] -> Using reference build 'DemoProject #42'
[Coverage] -> Found reference result in build 'DemoProject #42'
[Coverage] Obtaining action of reference build '${REF_5}'
[Coverage] -> Expanding reference build '${REF_5}' to '42'
[Coverage] -> Using reference build 'DemoProject #42'
[Coverage] -> Found reference result in build 'DemoProject #42'
[Coverage] Obtaining action of reference build '${REF_6}'
[Coverage] -> Expanding reference build '${REF_6}' to '-'
[Coverage] -> No such build '-'
[Coverage] -> No reference build defined for '${REF_6}'
[Coverage] Obtaining action of reference build '${REF_1}'
[Coverage] -> Expanding reference build '${REF_1}' to '1'
[Coverage] -> Using reference build 'DemoProject #1'
[Coverage] -> Found no reference result in reference build 'DemoProject #1'
[Coverage] Obtaining action of reference build '${REF_2}'
[Coverage] -> Expanding reference build '${REF_2}' to '9999999999999999999999999'
[Coverage] -> Invalid build number '9999999999999999999999999'
[Coverage] -> No such build '9999999999999999999999999'
[Coverage] -> No reference build defined for '${REF_2}'
[Coverage] Obtaining action of reference build '${REF_3}'
[Coverage] -> Expanding reference build '${REF_3}' to 'asdfghjkl'
[Coverage] -> No such build 'asdfghjkl'
[Coverage] -> No reference build defined for '${REF_3}'
[Coverage] Obtaining action of reference build '${REF_4}'
[Coverage] -> Expanding reference build '${REF_4}' to ''
[Coverage] -> No such build ''
[Coverage] -> No reference build defined for '${REF_4}'
```