### PR TITLE
Customize summary page to show information of quality gates

### DIFF
--- a/src/main/resources/com/parasoft/findings/jenkins/coverage/api/metrics/steps/CoverageBuildAction/summary.jelly
+++ b/src/main/resources/com/parasoft/findings/jenkins/coverage/api/metrics/steps/CoverageBuildAction/summary.jelly
@@ -19,7 +19,37 @@
             </li>
           </span>
         </j:if>
-        <c:qualityGate result="${it.qualityGateResult}" />
+        <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+          <j:set var="result" value="${it.qualityGateResult}"/>
+          <j:set var="status" value="${result.overallStatus}"/>
+          <j:if test="${status.name() != 'INACTIVE'}">
+            <li>${%quality.gate.title}: ${status.description}
+              <l:icon style="width: 16px; height: 16px; margin-left: 0; position: relative; top: -0.1rem;" alt="${status.description}" class="${status.iconClass} icon-sm"/>
+            </li>
+            <table class="jenkins-table">
+              <thead>
+                <tr>
+                  <th align="left">${%table.title.status}</th>
+                  <th align="left">${%table.title.quality.gate}</th>
+                  <th align="left">${%table.title.threshold}</th>
+                  <th align="left">${%table.title.actual}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <j:forEach var="item" items="${result.resultItems}">
+                  <tr>
+                    <td align="left">
+                      <l:icon style="width: 16px; height: 16px; margin-left: 0; position: relative; top: -0.1rem;" alt="${item.status.description}" class="${item.status.iconClass} icon-sm"/>
+                    </td>
+                    <td align="left" style="white-space: nowrap;">${item.qualityGate.name}</td>
+                    <td align="right" style="white-space: nowrap;">${item.qualityGate.threshold}%</td>
+                    <td align="right" style="white-space: nowrap;">${item.actualValue}</td>
+                  </tr>
+                </j:forEach>
+              </tbody>
+            </table>
+          </j:if>
+        </j:jelly>
       </ul>
     </div>
   </t:summary>

--- a/src/main/resources/com/parasoft/findings/jenkins/coverage/api/metrics/steps/CoverageBuildAction/summary.properties
+++ b/src/main/resources/com/parasoft/findings/jenkins/coverage/api/metrics/steps/CoverageBuildAction/summary.properties
@@ -1,3 +1,9 @@
 icon.info.tooltip=Click to see all logging messages during recording.
 project.title=Overall Project (with difference to reference)
 change.title=Changed Lines (with difference to overall project)
+
+quality.gate.title=Quality gate(s)
+table.title.status=Status
+table.title.quality.gate=Quality Gate(s)
+table.title.threshold=Threshold
+table.title.actual=Actual


### PR DESCRIPTION
If there is no quality gate added in configuration, the table would not be shown