### PR TITLE
Remove the URI prefixs when it's an external report

### DIFF
--- a/src/main/java/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder.java
+++ b/src/main/java/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder.java
@@ -23,7 +23,6 @@ import com.parasoft.findings.jenkins.coverage.model.ModuleNode;
 import com.parasoft.findings.jenkins.coverage.model.Node;
 import com.parasoft.findings.jenkins.util.FilteredLogChain;
 import edu.hm.hafner.util.FilteredLog;
-import edu.hm.hafner.util.TreeStringBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;

--- a/src/main/java/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder.java
+++ b/src/main/java/com/parasoft/findings/jenkins/coverage/ParasoftCoverageRecorder.java
@@ -242,17 +242,8 @@ public class ParasoftCoverageRecorder extends Recorder {
                                       FilteredLogChain logChain) throws InterruptedException {
         FilteredLog log = logChain.addNewFilteredLog("Errors while resolving source code files:");
         log.logInfo("Resolving source code files...");
-        var sources = rootNode.getSourceFolders();
-        var pathMapping = new PathResolver().resolvePaths(rootNode.getFiles(), sources, workspace, log);
+        var pathMapping = new PathResolver().resolvePaths(rootNode.getFiles(), workspace, log);
 
-        if (!pathMapping.isEmpty()) {
-            log.logInfo("Making paths of " + pathMapping.size() + " source code files relative to workspace root...");
-            var builder = new TreeStringBuilder();
-            rootNode.getAllFileNodes().stream()
-                    .filter(file -> pathMapping.containsKey(file.getRelativePath()))
-                    .forEach(file -> file.setRelativePath(builder.intern(pathMapping.get(file.getRelativePath()))));
-            builder.dedup();
-        }
         logChain.getLogHandler().log(log);
     }
 

--- a/src/main/resources/com/parasoft/findings/jenkins/coverage/cobertura.xsl
+++ b/src/main/resources/com/parasoft/findings/jenkins/coverage/cobertura.xsl
@@ -89,7 +89,7 @@
         <xsl:element name="packages">
             <!-- Group by the parent path of uri-->
             <xsl:for-each-group select="/Coverage/Locations/Loc" group-by="substring-before(@uri, tokenize(@uri, '/')[last()])">
-                <xsl:variable name="uriWithoutFilePrefix">
+                <xsl:variable name="theFirstUriWithoutFilePrefixInCurrentGroup">
                     <xsl:call-template name="getUriWithoutFilePrefix">
                         <xsl:with-param name="rawUri" select="@uri"/>
                     </xsl:call-template>
@@ -114,11 +114,11 @@
                         </xsl:variable>
                         <xsl:variable name="processedPipelineBuildWorkingDirectory">
                             <xsl:choose>
-                                <xsl:when test="string($uncodedPipelineBuildWorkingDirectory) != '' and contains($uriWithoutFilePrefix, $uncodedPipelineBuildWorkingDirectory)">
+                                <xsl:when test="string($uncodedPipelineBuildWorkingDirectory) != '' and contains($theFirstUriWithoutFilePrefixInCurrentGroup, $uncodedPipelineBuildWorkingDirectory)">
                                     <xsl:value-of select="$uncodedPipelineBuildWorkingDirectory"/>
                                 </xsl:when>
                                 <!-- Using encoded pipeline build working directory when the uri attribute of <Loc> tag in Parasoft tool report(e.g. jtest report) is encoded -->
-                                <xsl:when test="string($encodedPipelineBuildWorkingDirectory) != '' and contains($uriWithoutFilePrefix, $encodedPipelineBuildWorkingDirectory)">
+                                <xsl:when test="string($encodedPipelineBuildWorkingDirectory) != '' and contains($theFirstUriWithoutFilePrefixInCurrentGroup, $encodedPipelineBuildWorkingDirectory)">
                                     <xsl:value-of select="$encodedPipelineBuildWorkingDirectory"/>
                                 </xsl:when>
                                 <xsl:otherwise>
@@ -131,13 +131,13 @@
                             <xsl:choose>
                                 <xsl:when test="$isExternalReport">
                                     <xsl:call-template name="getPackageName">
-                                        <xsl:with-param name="projectPath" select="$uriWithoutFilePrefix"/>
+                                        <xsl:with-param name="projectPath" select="$theFirstUriWithoutFilePrefixInCurrentGroup"/>
                                     </xsl:call-template>
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <xsl:call-template name="getPackageName">
                                         <!-- Get relative source file path -->
-                                        <xsl:with-param name="projectPath" select="substring-after($uriWithoutFilePrefix, $processedPipelineBuildWorkingDirectory)"/>
+                                        <xsl:with-param name="projectPath" select="substring-after($theFirstUriWithoutFilePrefixInCurrentGroup, $processedPipelineBuildWorkingDirectory)"/>
                                     </xsl:call-template>
                                 </xsl:otherwise>
                             </xsl:choose>
@@ -150,14 +150,19 @@
                         </xsl:attribute>
                         <xsl:element name="classes">
                             <xsl:for-each select="current-group()">
+                                <xsl:variable name="sourceFileUriWithoutFilePrefix">
+                                    <xsl:call-template name="getUriWithoutFilePrefix">
+                                        <xsl:with-param name="rawUri" select="@uri"/>
+                                    </xsl:call-template>
+                                </xsl:variable>
                                 <xsl:variable name="filePath">
                                     <xsl:choose>
                                         <xsl:when test="$isExternalReport">
-                                            <xsl:value-of select="$uriWithoutFilePrefix"/>
+                                            <xsl:value-of select="$sourceFileUriWithoutFilePrefix"/>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <!-- Get relative source file path -->
-                                            <xsl:value-of select="substring-after($uriWithoutFilePrefix, $processedPipelineBuildWorkingDirectory)"/>
+                                            <xsl:value-of select="substring-after($sourceFileUriWithoutFilePrefix, $processedPipelineBuildWorkingDirectory)"/>
                                         </xsl:otherwise>
                                     </xsl:choose>
                                 </xsl:variable>

--- a/src/main/resources/com/parasoft/findings/jenkins/coverage/cobertura.xsl
+++ b/src/main/resources/com/parasoft/findings/jenkins/coverage/cobertura.xsl
@@ -158,11 +158,13 @@
                                 <xsl:variable name="filePath">
                                     <xsl:choose>
                                         <xsl:when test="$isExternalReport">
-                                            <xsl:value-of select="$sourceFileUriWithoutFilePrefix"/>
+                                            <!-- Replace %25 with % and %20 with space to get an uncoded path-->
+                                            <xsl:value-of select="replace(replace($sourceFileUriWithoutFilePrefix, '%25', '%'), '%20', ' ')"/>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <!-- Get relative source file path -->
-                                            <xsl:value-of select="substring-after($sourceFileUriWithoutFilePrefix, $processedPipelineBuildWorkingDirectory)"/>
+                                            <!-- Replace %25 with % and %20 with space to get an uncoded path-->
+                                            <xsl:value-of select="replace(replace(substring-after($sourceFileUriWithoutFilePrefix, $processedPipelineBuildWorkingDirectory), '%25', '%'), '%20', ' ')"/>
                                         </xsl:otherwise>
                                     </xsl:choose>
                                 </xsl:variable>
@@ -296,7 +298,8 @@
                     </xsl:when>
                     <!--     Dottest  or CPPTest std     -->
                     <xsl:when test="$toolName = 'dottest' or $toolName = 'c++test'">
-                        <xsl:value-of select="substring-before($projectPath, concat($delimiter, $filename))"/>
+                        <!-- Replace %25 with % and %20 with space to get an uncoded path-->
+                        <xsl:value-of select="replace(replace(substring-before($projectPath, concat($delimiter, $filename)), '%25', '%'), '%20', ' ')"/>
                     </xsl:when>
                 </xsl:choose>
             </xsl:when>


### PR DESCRIPTION
**Jenkins Version**: Jenkins 2.462.3 LTS

**Target**: The source code should be navigable without any exceptions in the console, regardless of whether it is in the current workspace or elsewhere on the agent.

**Checklist**: 
- [ ] **Local Windows agent**
        **Freestyle**: Parsing coverage report which uri starts with ‘file://hostname/XXX’,‘file:/XXX’ or ‘file:///XXX’
        **Pipeline**: Same as Freestyle.
- [ ] R**emote Windows agent**
        **Freestyle**: Parsing coverage report which uri starts with ‘file://hostname/XXX’,‘file:/XXX’ or ‘file:///XXX’
        **Pipeline**: Same as Freestyle.
- [ ] **Linux agent**
        **Freestyle**: Parsing coverage report which uri starts with ‘file://hostname/XXX’,‘file:/XXX’ or ‘file:///XXX’
        **Pipeline**: Same as Freestyle.