### PR TITLE
Exclude dependencies already provided by the JDK to prevent conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,16 @@
   <dependencies>
     <!-- Library Dependencies -->
     <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>xpp3</groupId>
+          <artifactId>xpp3</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>com.parasoft</groupId>
       <artifactId>parasoft-findings-utils</artifactId>
       <version>${parasoft-findings-utils.version}</version>
@@ -236,6 +246,12 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>warnings-ng</artifactId>
       <version>${warnings-ng.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,7 @@
   <dependencies>
     <!-- Library Dependencies -->
     <dependency>
+      <!-- This fixes a compilation error caused by a package being accessible from multiple modules. -->
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
       <exclusions>
@@ -246,6 +247,7 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>warnings-ng</artifactId>
       <version>${warnings-ng.version}</version>
+      <!-- This fixes a compilation error caused by a package being accessible from multiple modules. -->
       <exclusions>
         <exclusion>
           <groupId>xml-apis</groupId>


### PR DESCRIPTION
* Use **javax.xml.**** provided by the JDK instead of other modules.