### PR TITLE
Fix the color broken issue when hovering on the coverage overview and trend charts

### DIFF
--- a/src/main/resources/parasoftCoverage/trend-chart.jelly
+++ b/src/main/resources/parasoftCoverage/trend-chart.jelly
@@ -82,6 +82,18 @@ SOFTWARE.-->
                       }
                   });
               }
+              parasoftCoverageTrendChart.setOption({
+                  series: {
+                      emphasis: {
+                          itemStyle: {
+                              color: 'inherit'
+                          },
+                          lineStyle: {
+                              color: 'inherit'
+                          }
+                      }
+                  }
+              });      
           });
       }
     </script>

--- a/src/main/webapp/js/view-model.js
+++ b/src/main/webapp/js/view-model.js
@@ -159,6 +159,11 @@ const CoverageChartGenerator = function ($) {
                             color: coveredColor
                         }
                     },
+                    emphasis: {
+                        itemStyle: {
+                            color: 'inherit'
+                        }
+                    },
                     label: {
                         show: true,
                         position: 'insideLeft',
@@ -177,6 +182,11 @@ const CoverageChartGenerator = function ($) {
                     itemStyle: {
                         normal: {
                             color: missedColor
+                        }
+                    },
+                    emphasis: {
+                        itemStyle: {
+                            color: 'inherit'
                         }
                     },
                     label: {

--- a/src/main/webapp/js/view-model.js
+++ b/src/main/webapp/js/view-model.js
@@ -283,6 +283,16 @@ const CoverageChartGenerator = function ($) {
                                 title: setupText
                             }
                         }
+                    },
+                    series: {
+                        emphasis: {
+                            itemStyle: {
+                                color: 'inherit'
+                            },
+                            lineStyle: {
+                                color: 'inherit'
+                            }
+                        }
                     }
                 });
                 resizeChartOf('#coverage-trend');


### PR DESCRIPTION
References:

- [[JENKINS-75242] Coloring of charts broken due to oklch usage (Regression in 2.494) - Jenkins Jira](https://issues.jenkins.io/browse/JENKINS-75242)
- [[JENKINS-75242] Use \`{color: inherit}\` for emphasis · jenkinsci/coverage-plugin@94bd4e3](https://github.com/jenkinsci/coverage-plugin/commit/94bd4e3a5f7ed4f6eb810f085b9803f153298562)
- [OKLCH Color Support · Issue #20757 · apache/echarts](https://github.com/apache/echarts/issues/20757)
- [series-bar.emphasis.itemStyle. color - Documentation - Apache ECharts](https://echarts.apache.org/en/option.html#series-bar.emphasis.itemStyle.color)
- [series-line.emphasis.lineStyle. color - Documentation - Apache ECharts](https://echarts.apache.org/en/option.html#series-line.emphasis.lineStyle.color)